### PR TITLE
Delete method with tests.

### DIFF
--- a/linked_list.py
+++ b/linked_list.py
@@ -65,3 +65,25 @@ class LinkedList:
     def clear(self):
         self.head = None
         return
+
+    def _delete(self, previous, current, value):
+        if not current:
+            return
+
+        if current.value == value:
+            return_node = current
+            previous.nxt = current.nxt
+            return return_node
+
+        return self._delete(previous.nxt, current.nxt, value)
+
+    def delete(self, value):
+        if not self.head:
+            return
+
+        if self.head.value == value:
+            return_node = self.head
+            self.head = self.head.nxt
+            return return_node
+
+        return self._delete(self.head, self.head.nxt, value)

--- a/test_linked_list.py
+++ b/test_linked_list.py
@@ -221,3 +221,46 @@ class TestClearMethod:
     def test_clear_method_with_ten_nodes(self, lst_factory):
         """Lst with 10 nodes should return None when cleared."""
         assert not lst_factory.clear()
+
+
+class TestDeleteMethod:
+    def test_delete_with_empty_list(self):
+        """Empty list should return None."""
+        lst = LinkedList()
+        assert not lst.delete(1)
+
+    def test_delete_with_single_node_no_match(self, one_node):
+        """List with single non matching node value should return None"""
+        assert not one_node.delete(2)
+
+    def test_delete_with_single_node_match(self, one_node):
+        """List with single matching node value should return matching Node"""
+        match_node = one_node.head
+        assert one_node.delete(1) == match_node
+
+    def test_delete_with_single_node_match_returns_value(self, one_node):
+        """List with single matching node value should return node with correct value."""
+        match_node = one_node.delete(1)
+        assert match_node.value == 1
+
+    def test_delete_with_single_node_match_creates_empty_list(self, one_node):
+        """List with single matching node value should return node with correct value."""
+        one_node.delete(1)
+        assert not one_node.head
+
+    @pytest.mark.lst_factory_data([1, 2])
+    def test_delete_with_2_nodes_no_match(self, lst_factory):
+        """List with 2 non matching nodes should return none"""
+        assert not lst_factory.delete(3)
+
+    @pytest.mark.lst_factory_data([1, 2])
+    def test_delete_with_2_nodes_head_matches(self, lst_factory):
+        """List with single matching node value should return matching Node"""
+        match_node = lst_factory.head
+        assert lst_factory.delete(2) == match_node
+
+    @pytest.mark.lst_factory_data([1, 2])
+    def test_delete_with_2_nodes_returns_correct_value_of_head(self, lst_factory):
+        """List with single matching node value should return node with correct value."""
+        match_node = lst_factory.delete(2)
+        assert match_node.value == 2


### PR DESCRIPTION
Tests not complete. It will be easier to create more test when a 'print' method has first been created. That can be used to test against to reduce repetativeness in the tests.