### PR TITLE
Push method.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = test*, conftest.py

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,6 +1,9 @@
 import pytest
 
 from linked_list import LinkedList, Node
+from dbl_linked_list import DblList, DblNode
+
+""" Linked List Fixtures. """
 
 
 @pytest.fixture
@@ -34,6 +37,45 @@ def lst_factory_append(request):
 
     # Do something with the data
     lst = LinkedList()
+    for value in marker.args[0]:
+        lst.push(value)
+    return lst
+
+
+""" Dbl Linked List Fixtures. """
+
+
+@pytest.fixture
+def dbl_one_node():
+    lst = DblList()
+    lst.push(1)
+    return lst
+
+
+@pytest.fixture
+def dbl_one_node_appended():
+    lst = DblList()
+    lst.append(1)
+    return lst
+
+
+@pytest.fixture
+def dbl_lst_factory(request):
+    marker = request.node.get_closest_marker("dbl_lst_factory_data")
+
+    # Do something with the data
+    lst = DblList()
+    for value in marker.args[0]:
+        lst.push(value)
+    return lst
+
+
+@pytest.fixture
+def dbl_lst_factory_append(request):
+    marker = request.node.get_closest_marker("dbl_lst_factory_data")
+
+    # Do something with the data
+    lst = DblList()
     for value in marker.args[0]:
         lst.push(value)
     return lst

--- a/src/dbl_linked_list.py
+++ b/src/dbl_linked_list.py
@@ -14,3 +14,29 @@ class DblNode(Node):
 class DblList(LinkedList):
     def __init__(self, length=0, strict=False) -> None:
         super().__init__(length, strict)
+        self.__strict = strict
+        self.__type = None
+
+    def push(self, value):
+        """
+        A new node to the head of the list.
+        """
+
+        if not self.head:
+            self.length += 1
+            self.__type = type(value)
+            first_node = DblNode(value)
+            self.head = first_node
+            self.tail = first_node
+            return
+
+        if self.__strict:
+            if type(value) is not self.__type:
+                print("Strict list cannot contain multiple types.")
+                return False
+
+        self.length += 1
+        new_node = DblNode(value)
+        new_node.nxt = self.head
+        self.head.prev = new_node
+        self.head = new_node

--- a/src/test_dbl_linked_list.py
+++ b/src/test_dbl_linked_list.py
@@ -65,3 +65,46 @@ class TestDblListClassHead:
         """A DblList initializes with __stict as True passed as kw arg."""
         lst = DblList(strict=True)
         assert lst._LinkedList__strict
+
+
+class TestPushMethod:
+    def test_DblLinkedList_with_1_node_is_head(self, dbl_one_node):
+        """Push 1 value into DblList, that value should be the head's data"""
+        assert dbl_one_node.head.value == 1
+
+    def test_DblLinkedList_with_1_node_is_tail(self, dbl_one_node):
+        """Push 1 value into DblList, that value should be the head's data"""
+        assert dbl_one_node.tail.value == 1
+
+    def test_DblLinkedList_with_1_node_head_nxt_is_none(self, dbl_one_node):
+        """Push 1 value into DblList, head.nxt should be None"""
+        assert not dbl_one_node.head.nxt
+
+    def test_DblLinkedList_with_1_node_tail_nxt_is_none(self, dbl_one_node):
+        """Push 1 value into DblList, head.nxt should be None"""
+        assert not dbl_one_node.tail.nxt
+
+    @pytest.mark.dbl_lst_factory_data([1, 2])
+    def test_DblLinkedList_with_2_nodes_correct_head(self, dbl_lst_factory):
+        """2 values in DblList, last value pushed should be head's data"""
+        assert dbl_lst_factory.head.value == 2
+
+    @pytest.mark.dbl_lst_factory_data([1, 2])
+    def test_DblLinkedList_with_2_nodes_prev(self, dbl_lst_factory):
+        """2 values in DblList, first node pushed prev is head"""
+        assert dbl_lst_factory.head.nxt.prev == dbl_lst_factory.head
+
+    @pytest.mark.dbl_lst_factory_data([1, 2])
+    def test_DblList_with_2_nodes_correct_head_nxt_data(self, dbl_lst_factory):
+        """2 values in DblList, first value pushed should be head.nxt.data"""
+        assert dbl_lst_factory.head.nxt.value == 1
+
+    @pytest.mark.dbl_lst_factory_data([1, 2])
+    def test_DblLinkedList_with_2_nodes_correct_tail(self, dbl_lst_factory):
+        """2 values in DblList, first value pushed should be tail's value."""
+        assert dbl_lst_factory.tail.value == 1
+
+    @pytest.mark.dbl_lst_factory_data([1, 2])
+    def test_DblLinkedList_with_2_nodes_no_3rd_node(self, dbl_lst_factory):
+        """Push 2 values into DblList, there should be no 3rd node"""
+        assert not dbl_lst_factory.head.nxt.nxt


### PR DESCRIPTION
Push method from inherited LinkedList needs to be rewritten to include 'node.prev'.