### PR TITLE
Delete method.

### DIFF
--- a/src/dbl_linked_list.py
+++ b/src/dbl_linked_list.py
@@ -45,6 +45,7 @@ class DblList(LinkedList):
         """
         Add a node to the end of the list.
         value: must be supplied and supports any data type.
+        However values are restricted to a specific type with __strict
         """
         if not self.head:
             self.__type = type(value)
@@ -84,3 +85,58 @@ class DblList(LinkedList):
         self.tail = self.tail.prev
         self.tail.nxt = None
         return return_value
+
+    def delete(self, value, del_num=1, del_all=False):
+        """
+        Returns how many times the value was deleted from the list.
+        'del_num' parameter determines how many times a deletion will occur.
+        'del_num=1' (the default) will delete the first found instance only.
+        'del_all=True' will overide any value of 'del_num'
+        """
+        if type(del_num) is not int:
+            print("'del_num' param must be an int")
+            return 0
+
+        if type(del_all) is not bool:
+            print("'del_all' param must be a bool")
+            return 0
+
+        if del_num < 1:
+            print("'del_num=' parameter must be an int greater than 0")
+            return 0
+
+        if not self.head:
+            return 0
+
+        deleted = 0
+        # First keep checking if head matches
+        while self.head.value == value:
+            print(self.head.value)
+            self.head = self.head.nxt
+            deleted += 1
+            self.length -= 1
+            if not self.head:
+                self.tail = None
+                return deleted
+            if not del_all:
+                if deleted == del_num:
+                    return deleted
+
+        # Once head stops matching, continue through list
+        current = self.head.nxt
+        while current:
+            if current.value == value:
+                if self.tail == current:
+                    self.tail = self.tail.prev
+                    self.tail.nxt = None
+                else:
+                    current.nxt.prev = current.prev
+                    current.prev.nxt = current.nxt
+                deleted += 1
+                self.length -= 1
+                if not del_all:
+                    if deleted == del_num:
+                        return deleted
+            current = current.nxt
+
+        return deleted

--- a/src/test_dbl_linked_list.py
+++ b/src/test_dbl_linked_list.py
@@ -352,3 +352,143 @@ class TestTypeChecking:
         lst.append(node1)
         lst.append(node2)
         assert lst.head.value == node1
+
+
+class TestDeleteMethod:
+    def test_delete_with_empty_list(self):
+        """Empty list should return None."""
+        lst = DblList()
+        assert lst.delete(1) == 0
+
+    def test_delete_with_single_node_no_match(self, dbl_one_node):
+        """List with single non matching node value should return 0"""
+        assert dbl_one_node.delete(2) == 0
+
+    def test_delete_with_single_node_match(self, dbl_one_node):
+        """List with single matching node value should return 1"""
+        assert dbl_one_node.delete(1) == 1
+
+    def test_delete_with_single_node_match_creates_empty_list(self, dbl_one_node):
+        """List with single matching node value should return node with correct value."""
+        dbl_one_node.delete(1)
+        assert not dbl_one_node.head
+
+    @pytest.mark.dbl_lst_factory_data([1, 2])
+    def test_delete_with_2_nodes_no_match(self, dbl_lst_factory):
+        """List with 2 non matching nodes should return 0"""
+        assert dbl_lst_factory.delete(3) == 0
+
+    @pytest.mark.dbl_lst_factory_data([1, 2])
+    def test_delete_with_2_nodes_head_matches(self, dbl_lst_factory):
+        """List with single matching node value should return 1"""
+        assert dbl_lst_factory.delete(2) == 1
+
+    @pytest.mark.dbl_lst_factory_data([1, 2])
+    def test_delete_with_2_nodes_returns_correct_value_of_head(self, dbl_lst_factory):
+        """List with single matching node value should have only head node."""
+        dbl_lst_factory.delete(2)
+        assert dbl_lst_factory.head.value == 1
+
+    @pytest.mark.dbl_lst_factory_data([1, 2, 3])
+    def test_delete_with_3_nodes_no_match(self, dbl_lst_factory):
+        """List with 3 non matching nodes should return 0"""
+        assert dbl_lst_factory.delete(4) == 0
+
+    @pytest.mark.dbl_lst_factory_data([1, 2, 3])
+    def test_delete_with_3_nodes_head_matches(self, dbl_lst_factory):
+        """List with single matching node value should return 1"""
+        assert dbl_lst_factory.delete(3) == 1
+
+    @pytest.mark.dbl_lst_factory_data([1, 2, 3])
+    def test_delete_head_with_3_nodes_returns_correct_value_of_head(
+        self, dbl_lst_factory
+    ):
+        """List with single matching node value should return node with correct value."""
+        dbl_lst_factory.delete(3)
+        assert dbl_lst_factory.head.value == 2
+
+    @pytest.mark.dbl_lst_factory_data([1, 2, 3])
+    def test_delete_with_3_nodes_tail_matches(self, dbl_lst_factory):
+        """List with single matching last node value should return matching Node"""
+        dbl_lst_factory.delete(1)
+        assert dbl_lst_factory.head.nxt.value == 2
+
+    @pytest.mark.dbl_lst_factory_data([1, 2, 3])
+    def test_delete_with_3_nodes_tail_matches_remaining_nodes(self, dbl_lst_factory):
+        """List with single matching last node value should contain that node"""
+        dbl_lst_factory.delete(1)
+        assert dbl_lst_factory.__str__() == "[3, 2]"
+
+    @pytest.mark.dbl_lst_factory_data([1, 2, 3])
+    def test_delete_with_3_nodes_middle_node_returns_1(self, dbl_lst_factory):
+        """List with single matching mid node value should return 1"""
+        assert dbl_lst_factory.delete(2) == 1
+
+    @pytest.mark.dbl_lst_factory_data([1, 2, 3])
+    def test_delete_with_3_nodes_mid_node_matches_remaining_nodes(
+        self, dbl_lst_factory
+    ):
+        """List with single matching mid node value should not have that node"""
+        dbl_lst_factory.delete(2)
+        assert dbl_lst_factory.__str__() == "[3, 1]"
+
+    @pytest.mark.dbl_lst_factory_data([1, 2, 2])
+    def test_delete_with_3_nodes_delete_head_twice(self, dbl_lst_factory):
+        """Deleting head value creates a new head, test new head deletes also"""
+        dbl_lst_factory.delete(2, del_num=2)
+        assert dbl_lst_factory.__str__() == "[1]"
+
+    @pytest.mark.dbl_lst_factory_data([1, 2, 2])
+    def test_delete_with_3_nodes_delete_head_twice_returns_2(self, dbl_lst_factory):
+        """Deleting head value twice in 3 node list returns 2."""
+        assert dbl_lst_factory.delete(2, del_num=2) == 2
+
+    @pytest.mark.dbl_lst_factory_data([2, 2, 2])
+    def test_delete_with_3_nodes_delete_head_thrice_returns_3(self, dbl_lst_factory):
+        """Deleting head value thrice in 3 node list returns 2."""
+        assert dbl_lst_factory.delete(2, del_num=3) == 3
+
+    @pytest.mark.dbl_lst_factory_data([2] * 10)
+    def test_delete_with_10_nodes_delete_head_10_times_returns_10(
+        self, dbl_lst_factory
+    ):
+        """Deleting head value 10 times using del_all=true param."""
+        assert dbl_lst_factory.delete(2, del_all=True) == 10
+
+    @pytest.mark.dbl_lst_factory_data([2] * 10)
+    def test_length_with_10_nodes_delete_head_10_times(self, dbl_lst_factory):
+        """Deleting head value 10 times using del_all=true param."""
+        dbl_lst_factory.delete(2, del_all=True)
+        assert len(dbl_lst_factory) == 0
+
+    @pytest.mark.dbl_lst_factory_data([2, 1, 2, 1, 2, 1, 2, 1, 2, 1])
+    def test_delete_with_10_nodes_delete_all_even_indexes(self, dbl_lst_factory):
+        """Deleting all even index that have value 2 with del_all=true param."""
+        assert dbl_lst_factory.delete(2, del_all=True) == 5
+
+    @pytest.mark.dbl_lst_factory_data([2, 1, 2, 1, 2, 1, 2, 1, 2, 1])
+    def test_length_with_10_nodes_delete_all_even_indexes(self, dbl_lst_factory):
+        """Deleting all even index that have value 2 with del_all=true param."""
+        dbl_lst_factory.delete(2, del_all=True)
+        assert len(dbl_lst_factory) == 5
+
+    @pytest.mark.dbl_lst_factory_data([2, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    def test_delete_with_10_nodes_delete_all_nodes_but_head(self, dbl_lst_factory):
+        """Deleting all even index that have value 2 with del_all=true param."""
+        dbl_lst_factory.delete(1, del_num=9)
+        assert dbl_lst_factory.__str__() == "[2]"
+
+    def test_non_int_passed_as_param(self):
+        """Delete should return 0 if 'del_num' param is not int."""
+        ll = DblList()
+        assert ll.delete(1, del_num=1.1) == 0
+
+    def test_int_less_than_1_param(self):
+        """Delete should return 0 if 'del_num' is less than 1."""
+        ll = DblList()
+        assert ll.delete(1, del_num=0) == 0
+
+    def test_non_bool_passed_as_param(self):
+        """Delete should return 0 if 'del_all' param is not bool."""
+        ll = DblList()
+        assert ll.delete(1, del_all=1) == 0


### PR DESCRIPTION
Delete method needed to override inherited LinkedList 'delete' method to account for 'prev' node pointers in a doubly linked list.